### PR TITLE
Corrige casos de contratos que exibem a comparação indevida para itens com poucos similares

### DIFF
--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -285,9 +285,9 @@
                 [title]="item.mediana_valor">
                 <div
                   class="pr-3"
-                  *ngIf="item?.itensSemelhantes?.length <= 1 || item?.servico; else mostraMedianaEstado">
+                  *ngIf="item?.itensSemelhantes?.length <= 3 || item?.servico; else mostraMedianaEstado">
                   <app-tooltip-ajuda
-                    *ngIf="item?.itensSemelhantes?.length <= 1"
+                    *ngIf="item?.itensSemelhantes?.length <= 3"
                     [tipo]="'info'"
                     [descricao]="'Não existem produtos no estado com descrição e quantidade semelhantes para comparação.'"></app-tooltip-ajuda>
                   <app-tooltip-ajuda
@@ -305,9 +305,9 @@
                 [title]="item.mediana_valor * item.qt_itens_contrato">
                 <div
                   class="pr-3"
-                  *ngIf="item?.itensSemelhantes?.length <= 1 || item?.servico; else mostraMedianaTotalEstado">
+                  *ngIf="item?.itensSemelhantes?.length <= 3 || item?.servico; else mostraMedianaTotalEstado">
                   <app-tooltip-ajuda
-                    *ngIf="item?.itensSemelhantes?.length <= 1"
+                    *ngIf="item?.itensSemelhantes?.length <= 3"
                     [tipo]="'info'"
                     [descricao]="'Não existem produtos no estado com descrição e quantidade semelhantes para comparação.'"></app-tooltip-ajuda>
                   <app-tooltip-ajuda
@@ -322,13 +322,13 @@
               <td
                 class="numero align-middle"
                 [title]="item.mediana_valor"
-                [style.background-color]="item?.itensSemelhantes?.length > 1 && !item?.servico ? defineCorFundo(item.percentual_vs_estado) : 'white'"
+                [style.background-color]="item?.itensSemelhantes?.length > 3 && !item?.servico ? defineCorFundo(item.percentual_vs_estado) : 'white'"
                 [style.color]="defineCor(item.percentual_vs_estado)">
                 <div
                   class="pr-3"
-                  *ngIf="item?.itensSemelhantes?.length <= 1 || item?.servico; else mostraPercentualEstado">
+                  *ngIf="item?.itensSemelhantes?.length <= 3 || item?.servico; else mostraPercentualEstado">
                   <app-tooltip-ajuda
-                    *ngIf="item?.itensSemelhantes?.length <= 1"
+                    *ngIf="item?.itensSemelhantes?.length <= 3"
                     [tipo]="'info'"
                     [descricao]="'Não existem produtos no estado com descrição e quantidade semelhantes para comparação.'"></app-tooltip-ajuda>
                   <app-tooltip-ajuda

--- a/client/src/app/contratos/info-contrato/info-contrato.component.ts
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.ts
@@ -96,10 +96,14 @@ export class InfoContratoComponent implements OnInit {
                     map(itemComMediana => {
                       item = itemComMediana;
                       // Se não houver itens similares, o valor da mediana será NaN
-                      // Este trecho atribui um valor bem pequeno para que todos os itens sem semelhantes fiquem ordenados primeiro
-                      if (isNaN(item.mediana_valor) || (item.itensSemelhantes && item.itensSemelhantes.length === 1)) {
-                        item.mediana_valor = -1; // Não existem itens com preços negativos
-                        item.percentual_vs_estado = -1000000000; // Valor pequeno e improvável de ter algum item com preço menor
+                      // Este trecho atribui um valor bem pequeno para que todos os itens sem similares fiquem ordenados corretamente
+                      if (isNaN(item.mediana_valor) || (item.itensSemelhantes && item.itensSemelhantes.length <= 3)) {
+                        let denominador = 1; // denominador usado para ordenar itens entre 1 e nenhum item similar
+                        if (item.itensSemelhantes && item.itensSemelhantes !== null) {
+                          denominador = item.itensSemelhantes.length;
+                        }
+                        item.mediana_valor = -1 / denominador; // Não existem itens com preços negativos
+                        item.percentual_vs_estado = -1e10 / denominador; // Valor pequeno e improvável de ter algum item com preço menor
                       } else {
                         item.percentual_vs_estado = (item.vl_item_contrato - item.mediana_valor) / item.mediana_valor;
                       }


### PR DESCRIPTION
## Mudanças
- Corrige casos de contratos que exibem a comparação indevida para itens com poucos similares

Exemplos (contexto de compras emergenciais):
Com itens sem links
http://localhost:4200/contratos/75bd8851b61a0889f0dfce78d69cd5f8
Com itens sem mediana mas com link
http://localhost:4200/contratos/e7d948ee208dd943179593c9e40af3d4