### PR TITLE
Revisão da página de itens e de contratos

### DIFF
--- a/client/src/app/busca/busca-item/busca-item.component.html
+++ b/client/src/app/busca/busca-item/busca-item.component.html
@@ -79,7 +79,7 @@
                 </td>
                 <td class="align-middle nowrap">
                   <ngb-highlight
-                    [result]="itemSemelhante.nome_municipio | titlecase"
+                    [result]="(itemSemelhante.nome_municipio | titlecase) + ' - ' + itemSemelhante?.sigla_estado"
                     [term]="listaService.termoBusca">
                   </ngb-highlight>
                 </td>

--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -321,7 +321,6 @@
               </td>
               <td
                 class="numero align-middle"
-                [title]="item.mediana_valor"
                 [style.background-color]="item?.itensSemelhantes?.length > 1 && !item?.servico ? defineCorFundo(item.percentual_vs_estado) : 'white'"
                 [style.color]="defineCor(item.percentual_vs_estado)">
                 <div
@@ -337,8 +336,19 @@
                     [descricao]="'Não realizamos comparações entre serviços, pois eles variam muito em descrição e especificação.'"></app-tooltip-ajuda>
                 </div>
                 <ng-template #mostraPercentualEstado>
-                  <span *ngIf="item.percentual_vs_estado > 0">+</span>
-                  {{ item.percentual_vs_estado | percent:'1.1' }}
+                  <div
+                    *ngIf="item?.itensSemelhantes?.length <= 3"
+                    class='mediana'
+                    placement="top"
+                    ngbTooltip="A mediana foi calculada com base em poucos ({{ item?.itensSemelhantes?.length }}) produtos semelhantes">
+                    <span *ngIf="item.percentual_vs_estado > 0">+</span>
+                    {{ item.percentual_vs_estado | percent:'1.1' }}&nbsp;*
+                  </div>
+                  <div
+                    *ngIf="item?.itensSemelhantes?.length > 3">
+                    <span *ngIf="item.percentual_vs_estado > 0">+</span>
+                    {{ item.percentual_vs_estado | percent:'1.1' }}&nbsp;&nbsp;
+                  </div>
                 </ng-template>
               </td>
               <td

--- a/client/src/app/contratos/info-contrato/info-contrato.component.scss
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.scss
@@ -51,3 +51,7 @@
   margin-top: 0;
   margin-bottom: 0.4rem;
 }
+
+.mediana {
+  cursor: pointer;
+}

--- a/client/src/app/itens/info-item/info-item.component.html
+++ b/client/src/app/itens/info-item/info-item.component.html
@@ -59,7 +59,7 @@
     </div>
 
     <h4>
-      Produtos semelhantes comprados em outros municípios
+      Produtos semelhantes comprados em outros contratos
     </h4>
 
     <ngb-alert [dismissible]="false" *ngIf="item?.itensSemelhantes?.length > 1">
@@ -98,7 +98,7 @@
                 ordenavel="ano_licitacao"
                 (ordenar)="onOrdenar($event)"
                 appOrdenavel>
-                Compra
+                Contrato
               </th>
               <th
                 scope="col"

--- a/client/src/app/itens/info-item/info-item.component.html
+++ b/client/src/app/itens/info-item/info-item.component.html
@@ -1,7 +1,7 @@
 <div class="view-container" *ngIf="item">
   <app-barra-titulo
     [titulo]="item.ds_item_resumido | titlecase"
-    [subtitulo]="item.itensContratoOrgao.nm_orgao + ' &#9474; Contrato nº ' + item.nr_contrato + '/' + item.ano_contrato"
+    [subtitulo]="item.itensContratoOrgao.nm_orgao + ' &#9474; ' + getNomeContrato(item)"
     [exibirVoltar]="true"></app-barra-titulo>
 
   <div class="container">
@@ -124,9 +124,16 @@
               <td class="align-middle nowrap">{{ itemSemelhante.nome_municipio | titlecase }}</td>
               <td class="align-middle text-right">
                 <a
+                  *ngIf="itemSemelhante?.tipo_instrumento_contrato !== 'Compra'"
                   [routerLink]="['/contratos/' + itemSemelhante.id_contrato]"
                   target="_blank">
                   nº {{ itemSemelhante.nr_contrato }}/{{ itemSemelhante.ano_licitacao }}
+                </a>
+                <a
+                  *ngIf="itemSemelhante?.tipo_instrumento_contrato === 'Compra'"
+                  [routerLink]="['/contratos/' + itemSemelhante.id_contrato]"
+                  target="_blank">
+                  Compra sem contrato (licitação {{ itemSemelhante?.nr_licitacao }}/{{ itemSemelhante?.ano_licitacao }})
                 </a>
               </td>
               <td class="numero align-middle">

--- a/client/src/app/itens/info-item/info-item.component.html
+++ b/client/src/app/itens/info-item/info-item.component.html
@@ -16,7 +16,7 @@
       </div>
       <div class="col-lg-5">
         <div class="row">
-          <div class="col-md-6 text-right" *ngIf="item?.itensSemelhantes?.length > 3">
+          <div class="col-md-6 text-right" *ngIf="item?.itensSemelhantes?.length > 1">
             <div>
               <strong>Mediana do estado</strong>
             </div>
@@ -24,7 +24,7 @@
               {{ item.mediana_valor | currency: "R$" }}
             </div>
           </div>
-          <div class="col-md-6 text-right" *ngIf="item?.itensSemelhantes?.length <= 3"></div>
+          <div class="col-md-6 text-right" *ngIf="item?.itensSemelhantes?.length <= 1"></div>
 
           <div class="col-md-6 text-right">
             <div>
@@ -33,7 +33,7 @@
             <div class="numero numero-destaque">
               {{ item.vl_item_contrato | currency: "R$" }}
             </div>
-            <div class="small" *ngIf="item?.itensSemelhantes?.length > 3">
+            <div class="small" *ngIf="item?.itensSemelhantes?.length > 1">
               <span
                 *ngIf="(item.vl_item_contrato - item.mediana_valor) < 0"
                 class="negativo">

--- a/client/src/app/itens/info-item/info-item.component.ts
+++ b/client/src/app/itens/info-item/info-item.component.ts
@@ -112,4 +112,14 @@ export class InfoItemComponent implements OnInit {
   defineCor(valor: number): string {
     return (valor >= 0.7 || valor <= -0.7) ? 'white' : 'black';
   }
+
+  getNomeContrato(item: ItensContrato) {
+    if (item !== null && item !== undefined) {
+      if (item.tp_instrumento_contrato === 'Compra') {
+        return 'Compra sem contrato (licitação ' + item.nr_licitacao + '/' + item.ano_licitacao + ')';
+      }
+      return 'Contrato nº ' + item.nr_contrato + '/' + item.ano_contrato;
+    }
+    return '';
+  }
 }

--- a/client/src/app/shared/models/itensContrato.model.ts
+++ b/client/src/app/shared/models/itensContrato.model.ts
@@ -23,4 +23,6 @@ export interface ItensContrato {
   itensContratoOrgao: any;
   alertaAtipico: any;
   resumido: boolean;
+  tp_instrumento_contrato: string;
+  nr_licitacao: string;
 }

--- a/server/routes/api/itensContrato.js
+++ b/server/routes/api/itensContrato.js
@@ -140,7 +140,7 @@ router.get("/search", (req, res) => {
 
   const termo = req.query.termo.replace(/[&|!<()\\:',]/gi, '').replace( /\s+/g, ' ').trim().split(' ').join(' & ');
   let query = `SELECT ano_licitacao, id_item_contrato, id_contrato, nr_contrato, id_licitacao, vl_item_contrato, \
-                      vl_total_item_contrato, ds_item, dt_inicio_vigencia, qt_itens_contrato, nome_municipio, \
+                      vl_total_item_contrato, ds_item, dt_inicio_vigencia, qt_itens_contrato, nome_municipio, sigla_estado, \
                       ts_rank(item_search.document, to_tsquery('portuguese', '${termo}')) as rel, \ 
                       sg_unidade_medida \
                       FROM item_search WHERE \

--- a/server/routes/api/itensContrato.js
+++ b/server/routes/api/itensContrato.js
@@ -117,6 +117,7 @@ router.post("/similares", (req, res) => {
   dataFinal = dataFinal.toJSON().slice(0, 10);
 
   let query = `SELECT ano_licitacao, id_item_contrato, id_contrato, nr_contrato, id_licitacao, vl_item_contrato, \
+                      nr_licitacao, tipo_instrumento_contrato, \
                       vl_total_item_contrato, ds_item, dt_inicio_vigencia, qt_itens_contrato, nome_municipio, id_estado,\
                       ts_rank(item_search.document, to_tsquery('portuguese', '${termoRanking}')) as rel, \ 
                       sg_unidade_medida \


### PR DESCRIPTION
## Mudanças
- Adiciona sigla do estado no nome do munícipio na página de busca de produtos
- Altera textos na página do item
- Modifica exibição do número do contrato para casos de compras emergenciais
- Altera critério para exibição da mediana na página do item
- Exibe marca para indicar produtos comparados com poucos itens semelhantes