### PR TITLE
Adiciona componente para alerta de fornecedores inidôneos

### DIFF
--- a/client/src/app/alertas/alertas.module.ts
+++ b/client/src/app/alertas/alertas.module.ts
@@ -14,6 +14,7 @@ import { CardAlertaComponent } from './card-alerta/card-alerta.component';
 import { FiltroAlertasComponent } from './filtro-alertas/filtro-alertas.component';
 import { AlertaAberturaEmpresaComponent } from './card-alerta/alerta-abertura-empresa/alerta-abertura-empresa.component';
 import { AlertaItemAtipicoComponent } from './card-alerta/alerta-item-atipico/alerta-item-atipico.component';
+import { AlertaInidoneosComponent } from './card-alerta/alerta-inidoneos/alerta-inidoneos.component';
 import { MenuAlertaComponent } from './menu-alerta/menu-alerta.component';
 
 @NgModule({
@@ -22,7 +23,8 @@ import { MenuAlertaComponent } from './menu-alerta/menu-alerta.component';
     FiltroAlertasComponent,
     AlertaAberturaEmpresaComponent,
     AlertaItemAtipicoComponent,
-    MenuAlertaComponent],
+    MenuAlertaComponent,
+    AlertaInidoneosComponent],
   imports: [
     CommonModule,
     FormsModule,

--- a/client/src/app/alertas/card-alerta/alerta-inidoneos/alerta-inidoneos.component.html
+++ b/client/src/app/alertas/card-alerta/alerta-inidoneos/alerta-inidoneos.component.html
@@ -1,0 +1,3 @@
+<div>
+    <span class="text-muted">{{ alerta?.info }}</span>
+</div>

--- a/client/src/app/alertas/card-alerta/alerta-inidoneos/alerta-inidoneos.component.html
+++ b/client/src/app/alertas/card-alerta/alerta-inidoneos/alerta-inidoneos.component.html
@@ -1,3 +1,3 @@
 <div>
-    <span class="text-muted">{{ alerta?.info }}</span>
+  <span class="text-muted">{{ alerta?.info }}</span>
 </div>

--- a/client/src/app/alertas/card-alerta/alerta-inidoneos/alerta-inidoneos.component.spec.ts
+++ b/client/src/app/alertas/card-alerta/alerta-inidoneos/alerta-inidoneos.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AlertaInidoneosComponent } from './alerta-inidoneos.component';
+
+describe('AlertaInidoneosComponent', () => {
+  let component: AlertaInidoneosComponent;
+  let fixture: ComponentFixture<AlertaInidoneosComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AlertaInidoneosComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AlertaInidoneosComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/alertas/card-alerta/alerta-inidoneos/alerta-inidoneos.component.ts
+++ b/client/src/app/alertas/card-alerta/alerta-inidoneos/alerta-inidoneos.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-alerta-inidoneos',
+  templateUrl: './alerta-inidoneos.component.html',
+  styleUrls: ['./alerta-inidoneos.component.scss']
+})
+export class AlertaInidoneosComponent implements OnInit {
+
+  @Input() alerta;
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/client/src/app/alertas/card-alerta/alerta-item-atipico/alerta-item-atipico.component.ts
+++ b/client/src/app/alertas/card-alerta/alerta-item-atipico/alerta-item-atipico.component.ts
@@ -1,17 +1,14 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-alerta-item-atipico',
   templateUrl: './alerta-item-atipico.component.html',
   styleUrls: ['./alerta-item-atipico.component.scss']
 })
-export class AlertaItemAtipicoComponent implements OnInit {
+export class AlertaItemAtipicoComponent {
 
   @Input() alerta;
 
   constructor() { }
-
-  ngOnInit() {
-  }
 
 }

--- a/client/src/app/alertas/card-alerta/card-alerta.component.html
+++ b/client/src/app/alertas/card-alerta/card-alerta.component.html
@@ -4,8 +4,8 @@
   [ngClass]="getStyleCard(alerta?.id_tipo)">
   <div
     class="card-body"
-    (click)="onClickCard(alerta?.id_contrato )"
-    [ngClass]="!alerta?.id_contrato ? 'card-alert-disabled' : ''">
+    (click)="onClickCard(alerta?.id_contrato, alerta?.nr_documento, alerta?.id_tipo)"
+    [ngClass]="!alerta?.id_contrato && !TIPOS_ALERTAS_FORNECEDORES.includes(alerta?.id_tipo) ? 'card-alert-disabled' : ''">
     <div class="text-muted title-border">
       <small>
         <strong>{{ alerta?.AlertaTipo?.titulo }}</strong>
@@ -39,7 +39,13 @@
     <div *ngIf="alerta?.id_tipo === 2">
       <app-alerta-item-atipico [alerta]="alerta"></app-alerta-item-atipico>
     </div>
-    <ngb-alert [dismissible]="false" type="light" *ngIf="!alerta?.id_contrato" class="container custom-alert-card mt-3 mb-1">
+
+    <div *ngIf="alerta?.id_tipo === 3">
+      <app-alerta-inidoneos [alerta]="alerta"></app-alerta-inidoneos>
+    </div>
+
+    <ngb-alert [dismissible]="false" type="light" *ngIf="!alerta?.id_contrato && !TIPOS_ALERTAS_FORNECEDORES.includes(alerta?.id_tipo)" 
+      class="container custom-alert-card mt-3 mb-1">
       <small >
         <strong>
           Este contrato não está presente na base de dados do site por estar relacionado a outro contexto.

--- a/client/src/app/alertas/card-alerta/card-alerta.component.html
+++ b/client/src/app/alertas/card-alerta/card-alerta.component.html
@@ -44,7 +44,7 @@
       <app-alerta-inidoneos [alerta]="alerta"></app-alerta-inidoneos>
     </div>
 
-    <ngb-alert [dismissible]="false" type="light" *ngIf="!alerta?.id_contrato && !TIPOS_ALERTAS_FORNECEDORES.includes(alerta?.id_tipo)" 
+    <ngb-alert [dismissible]="false" type="light" *ngIf="!alerta?.id_contrato && !TIPOS_ALERTAS_FORNECEDORES.includes(alerta?.id_tipo)"
       class="container custom-alert-card mt-3 mb-1">
       <small >
         <strong>

--- a/client/src/app/alertas/card-alerta/card-alerta.component.ts
+++ b/client/src/app/alertas/card-alerta/card-alerta.component.ts
@@ -1,5 +1,5 @@
+import { Component, Input } from '@angular/core';
 import { Router } from '@angular/router';
-import { Component, Input, OnInit } from '@angular/core';
 
 import { Alerta } from 'src/app/shared/models/alerta.model';
 
@@ -8,16 +8,13 @@ import { Alerta } from 'src/app/shared/models/alerta.model';
   templateUrl: './card-alerta.component.html',
   styleUrls: ['./card-alerta.component.scss']
 })
-export class CardAlertaComponent implements OnInit {
+export class CardAlertaComponent {
 
   public TIPOS_ALERTAS_FORNECEDORES = [3];
 
   @Input() alerta: Alerta;
 
   constructor(private router: Router) { }
-
-  ngOnInit() {
-  }
 
   getStyleCard(idAlerta) {
     if (1 === idAlerta) {
@@ -28,8 +25,6 @@ export class CardAlertaComponent implements OnInit {
       return { 'cor-borda-esquerda-inidoneo': true };
     }
   }
-
-
 
   onClickCard(idContrato, nrDocumento, tipoAlerta) {
     if (idContrato) {

--- a/client/src/app/alertas/card-alerta/card-alerta.component.ts
+++ b/client/src/app/alertas/card-alerta/card-alerta.component.ts
@@ -10,6 +10,8 @@ import { Alerta } from 'src/app/shared/models/alerta.model';
 })
 export class CardAlertaComponent implements OnInit {
 
+  public TIPOS_ALERTAS_FORNECEDORES = [3];
+
   @Input() alerta: Alerta;
 
   constructor(private router: Router) { }
@@ -22,14 +24,18 @@ export class CardAlertaComponent implements OnInit {
       return { 'cor-borda-esquerda-abertura-empresa': true };
     } else if (2 === idAlerta) {
       return { 'cor-borda-esquerda-item-atipico': true };
+    } else if (3 === idAlerta) {
+      return { 'cor-borda-esquerda-inidoneo': true };
     }
   }
 
 
 
-  onClickCard(idContrato) {
+  onClickCard(idContrato, nrDocumento, tipoAlerta) {
     if (idContrato) {
       this.router.navigate(['/contratos/' + idContrato]);
+    } else if (nrDocumento && this.TIPOS_ALERTAS_FORNECEDORES.includes(tipoAlerta)) {
+      this.router.navigate(['/fornecedores/' + nrDocumento]);
     }
   }
 

--- a/client/src/app/alertas/menu-alerta/menu-alerta.component.ts
+++ b/client/src/app/alertas/menu-alerta/menu-alerta.component.ts
@@ -43,6 +43,8 @@ export class MenuAlertaComponent implements OnInit, OnDestroy {
       return { 'cor-borda-inferior-abertura-empresa': true };
     } else if (2 === idAlerta) {
       return { 'cor-borda-inferior-item-atipico': true };
+    } else if (3 === idAlerta) {
+      return { 'cor-borda-inferior-inidoneo': true };
     }
   }
 
@@ -51,6 +53,8 @@ export class MenuAlertaComponent implements OnInit, OnDestroy {
       return { 'cor-alerta-abertura-empresa': true };
     } else if (2 === idAlerta) {
       return { 'cor-alerta-item-atipico': true };
+    } else if (3 === idAlerta) {
+      return { 'cor-alerta-inidoneo': true };
     }
   }
 

--- a/client/src/app/fornecedores/info-fornecedor/info-fornecedor.component.html
+++ b/client/src/app/fornecedores/info-fornecedor/info-fornecedor.component.html
@@ -220,6 +220,11 @@
             <span class="tooltip-base tooltip-warning icon-alert-triangle mr-1">
             </span>
             A empresa forneceu produtos que não são comuns com base em suas atividades econômicas declaradas na Receita Federal.
+          </p>          
+          <p *ngIf="alerta?.id_tipo === 3" class="custom-alert-text cursor-pointer" (click)="onClickAlerta(fornecedor?.nr_documento)">
+            <span class="tooltip-base tooltip-warning icon-alert-triangle mr-1">
+            </span>
+            {{ alerta?.info }}
           </p>
         </div>
       </div>

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -109,6 +109,10 @@ a.link-light:visited {
   background: #90448e;
 }
 
+.cor-alerta-inidoneo:before {
+  background: $green;
+}
+
 .cor-borda-esquerda-abertura-empresa {
   border-left-color: $warning !important;
 }
@@ -117,12 +121,20 @@ a.link-light:visited {
   border-left-color: #90448e !important;
 }
 
+.cor-borda-esquerda-inidoneo {
+  border-left-color: $green !important;
+}
+
 .cor-borda-inferior-abertura-empresa {
   border-bottom-color: $warning !important;
 }
 
 .cor-borda-inferior-item-atipico {
   border-bottom-color: #90448e !important;
+}
+
+.cor-borda-inferior-inidoneo {
+  border-bottom-color: $green !important;
 }
 
 .text-contratacao {


### PR DESCRIPTION
## Mudanças
- Adiciona componente para alerta de fornecedores inidôneos
- Exibe mensagem de alerta na página de fornecedores que foram considerados inidôneos

## Flags
- Depende da versão de dados do PR https://github.com/analytics-ufcg/ta-de-pe-dados/pull/153. 
Caso preferir baixe um sample com os dados gerados de alertas [aqui](https://drive.google.com/drive/u/0/folders/1K6pi05yGDxCEPTBQxb1T2IY6SSpI5fVU)
- Filtro por estado por enquanto não está funcionando para o novo alerta (task criada no taiga)