### PR TITLE
Adiciona mudanças no alerta de inidôneos

### DIFF
--- a/client/src/app/alertas/card-alerta/card-alerta.component.html
+++ b/client/src/app/alertas/card-alerta/card-alerta.component.html
@@ -4,7 +4,7 @@
   [ngClass]="getStyleCard(alerta?.id_tipo)">
   <div
     class="card-body"
-    (click)="onClickCard(alerta?.id_contrato, alerta?.nr_documento, alerta?.id_tipo)"
+    (click)="onClickCard(alerta?.id_contrato)"
     [ngClass]="!alerta?.id_contrato && !TIPOS_ALERTAS_FORNECEDORES.includes(alerta?.id_tipo) ? 'card-alert-disabled' : ''">
     <div class="text-muted title-border">
       <small>
@@ -44,7 +44,7 @@
       <app-alerta-inidoneos [alerta]="alerta"></app-alerta-inidoneos>
     </div>
 
-    <ngb-alert [dismissible]="false" type="light" *ngIf="!alerta?.id_contrato && !TIPOS_ALERTAS_FORNECEDORES.includes(alerta?.id_tipo)" 
+    <ngb-alert [dismissible]="false" type="light" *ngIf="!alerta?.id_contrato" 
       class="container custom-alert-card mt-3 mb-1">
       <small >
         <strong>

--- a/client/src/app/alertas/card-alerta/card-alerta.component.ts
+++ b/client/src/app/alertas/card-alerta/card-alerta.component.ts
@@ -10,7 +10,6 @@ import { Alerta } from 'src/app/shared/models/alerta.model';
 })
 export class CardAlertaComponent implements OnInit {
 
-  public TIPOS_ALERTAS_FORNECEDORES = [3];
 
   @Input() alerta: Alerta;
 
@@ -31,11 +30,9 @@ export class CardAlertaComponent implements OnInit {
 
 
 
-  onClickCard(idContrato, nrDocumento, tipoAlerta) {
+  onClickCard(idContrato) {
     if (idContrato) {
       this.router.navigate(['/contratos/' + idContrato]);
-    } else if (nrDocumento && this.TIPOS_ALERTAS_FORNECEDORES.includes(tipoAlerta)) {
-      this.router.navigate(['/fornecedores/' + nrDocumento]);
     }
   }
 

--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -134,6 +134,12 @@
             <span class="tooltip-base tooltip-warning icon-alert-triangle mr-1"></span>
             A empresa forneceu produtos que não são comuns com base em suas atividades econômicas declaradas na Receita Federal.
           </p>
+          <p
+            *ngIf="contrato?.contratoAlerta?.id_tipo === 3"
+            class="custom-alert-text">
+            <span class="tooltip-base tooltip-warning icon-alert-triangle mr-1"></span>
+            {{ contrato?.contratoAlerta?.info}}
+          </p>
         </div>
       </div>
     </ngb-alert>

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
@@ -125,6 +125,15 @@
                   Receita Federal.
                 </ngb-alert>
               </div>
+              <div>
+                <span
+                  *ngIf="contrato.tipo_alerta === 3"
+                  class="badge-pill badge-inidoneo tooltip-base"
+                  placement="top"
+                  ngbTooltip="O fornecedor estava com uma sanção vigente no momento da contratação.">
+                  Contratado inidôneo
+                </span>
+              </div>
             </div>
           </td>
 

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -445,6 +445,10 @@ th[ordenavel].asc:before {
   background: #90448e;
 }
 
+.badge-inidoneo {
+  background: $green;
+}
+
 .app-seletor {
   height: calc(1.5em + .75rem + 4px);
   padding: .375rem .75rem;


### PR DESCRIPTION
## Mudanças
- Considera o alerta de inidôneos por contrato e não mais por fornecedor
- Desativa o link do card quando o alerta se referir a um contrato externo e não monitorado