### PR TITLE
Altera alinhamento para encaixar licitações sem contrato

### DIFF
--- a/client/src/app/itens/info-item/info-item.component.html
+++ b/client/src/app/itens/info-item/info-item.component.html
@@ -16,7 +16,7 @@
       </div>
       <div class="col-lg-5">
         <div class="row">
-          <div class="col" *ngIf="item?.itensSemelhantes?.length > 1">
+          <div class="col text-center" *ngIf="item?.itensSemelhantes?.length > 1">
             <div>
               <strong>Contrato</strong>
             </div>
@@ -34,7 +34,7 @@
             </a>
           </div>
 
-          <div class="col" *ngIf="item?.itensSemelhantes?.length > 1">
+          <div class="col text-center" *ngIf="item?.itensSemelhantes?.length > 1">
             <div>
               <strong>Mediana do estado</strong>
             </div>
@@ -44,7 +44,7 @@
           </div>
           <div class="col" *ngIf="item?.itensSemelhantes?.length <= 1"></div>
 
-          <div class="col">
+          <div class="col text-center">
             <div>
               <strong>Valor por unidade</strong>
             </div>

--- a/client/src/app/itens/info-item/info-item.component.scss
+++ b/client/src/app/itens/info-item/info-item.component.scss
@@ -26,7 +26,7 @@
 
 .item-destaque-wrapper .row{
   display: grid;
-  grid-template-columns: repeat(3, max-content);
+  grid-template-columns: repeat(3, auto);
 }
 
 .table-th-dividido-up {


### PR DESCRIPTION
## A issue
O alinhamento dos itens não funcionava para itens advindos de licitações sem contrato.
![Descrição com desalinhamento](https://user-images.githubusercontent.com/47047853/131169274-1f6578c3-95ef-4937-90fe-7c1865c5f261.png)

## O que foi feito
Alteração no css para centralizar o texto e o tamanho das colunas ser dinâmico.

## Exemplo com a mudança
![Descrição com correção de alinhamento](https://user-images.githubusercontent.com/47047853/131169725-e3fedc12-f8fb-4976-89f0-04330820f066.png)
