### PR TITLE
Reordena lista de opções no dropdown de busca

### DIFF
--- a/client/src/app/shared/components/input-busca-geral/input-busca-geral.component.html
+++ b/client/src/app/shared/components/input-busca-geral/input-busca-geral.component.html
@@ -3,7 +3,7 @@
   let-r="result"
   let-t="term">
   <span
-    *ngIf="r?.tipoBusca=='COMPRA' || r?.tipoBusca=='ITEM' || r?.tipoBusca=='MUNICIPIO_BUSCA' || r?.tipoBusca=='FORNECEDOR'"
+    *ngIf="r?.tipoBusca=='COMPRA' || r?.tipoBusca=='ITEM' || r?.tipoBusca=='FORNECEDOR' || r?.tipoBusca=='MUNICIPIO_BUSCA'"
     class="icon-search mr-1"></span>
 
   <span *ngIf="r?.tipoBusca=='COMPRA'">
@@ -16,14 +16,14 @@
     <strong>produtos</strong>
     com o termo "</span>
 
-  <span *ngIf="r?.tipoBusca=='MUNICIPIO_BUSCA'">
-    Buscar
-    <strong>municípios</strong>
-    com o termo "</span>
-
   <span *ngIf="r?.tipoBusca=='FORNECEDOR'">
     Buscar
     <strong>fornecedores</strong>
+    com o termo "</span>
+
+  <span *ngIf="r?.tipoBusca=='MUNICIPIO_BUSCA'">
+    Buscar
+    <strong>municípios</strong>
     com o termo "</span>
 
   <span
@@ -40,7 +40,7 @@
     [term]="t">
   </ngb-highlight>
   <span *ngIf="r?.tipoBusca=='MUNICIPIO'">– {{ r?.siglaEstado}}</span>
-  <span *ngIf="r?.tipoBusca=='COMPRA' || r?.tipoBusca=='ITEM' || r?.tipoBusca=='MUNICIPIO_BUSCA' || r?.tipoBusca=='FORNECEDOR'">"</span>
+  <span *ngIf="r?.tipoBusca=='COMPRA' || r?.tipoBusca=='ITEM' || r?.tipoBusca=='FORNECEDOR' || r?.tipoBusca=='MUNICIPIO_BUSCA'">"</span>
   <hr *ngIf="r?.tipoBusca=='COMPRA'">
 </ng-template>
 

--- a/client/src/app/shared/components/input-busca-geral/input-busca-geral.component.ts
+++ b/client/src/app/shared/components/input-busca-geral/input-busca-geral.component.ts
@@ -95,8 +95,8 @@ export class InputBuscaGeralComponent implements OnInit {
             ).slice(0, 4);
             buscaveisTemp.unshift (new Buscavel(term, TipoBusca.Compra));
             buscaveisTemp.unshift (new Buscavel(term, TipoBusca.Item));
-            buscaveisTemp.unshift (new Buscavel(term, TipoBusca.MunicipioBusca));
             buscaveisTemp.unshift (new Buscavel(term, TipoBusca.Fornecedor));
+            buscaveisTemp.unshift (new Buscavel(term, TipoBusca.MunicipioBusca));
             return buscaveisTemp;
         } else {
           return [];

--- a/client/src/app/shared/components/input-busca-geral/input-busca-geral.component.ts
+++ b/client/src/app/shared/components/input-busca-geral/input-busca-geral.component.ts
@@ -114,10 +114,10 @@ export class InputBuscaGeralComponent implements OnInit {
         this.router.navigate(['busca/contrato'], { queryParams: { termo: buscavel.descricao }});
       } else if (buscavel.tipoBusca === TipoBusca.Item) {
         this.router.navigate(['busca/produto'], { queryParams: { termo: buscavel.descricao }});
-      } else if (buscavel.tipoBusca === TipoBusca.MunicipioBusca) {
-        this.router.navigate(['busca/municipio'], { queryParams: { termo: buscavel.descricao }});
       } else if (buscavel.tipoBusca === TipoBusca.Fornecedor) {
         this.router.navigate(['busca/fornecedor'], { queryParams: { termo: buscavel.descricao }});
+      } else if (buscavel.tipoBusca === TipoBusca.MunicipioBusca) {
+        this.router.navigate(['busca/municipio'], { queryParams: { termo: buscavel.descricao }});
       }
     }
     this.limpaInputPesquisa();


### PR DESCRIPTION
## Linkando issue:
Closes #359

## O que foi feito:
- Alteração da ordem dos elementos no código

## Exemplo de uso:
![Dropdown de busca na ordem: municípios, fornecedores, itens e contratos](https://user-images.githubusercontent.com/47047853/131546479-6f19e0d8-8a55-4680-9828-076ae82dac87.png)
