### PR TITLE
Adiciona regra de formatação de CPF de 6 dígitos

### DIFF
--- a/client/src/app/alertas/card-alerta/card-alerta.component.html
+++ b/client/src/app/alertas/card-alerta/card-alerta.component.html
@@ -24,7 +24,7 @@
       </span>
       <span *ngIf="!alerta?.alertaFornecedor?.nm_pessoa">fornecedor sem nome cadastrado</span>
       <small class="font-weight-bold">
-        (<ngb-highlight [result]="alerta?.nr_documento | formatCpfCnpj"></ngb-highlight>)
+        (<ngb-highlight [result]="alerta?.nr_documento | formatCpfCnpj:alerta?.alertaFornecedor?.tp_pessoa"></ngb-highlight>)
       </small>
 
       <span *ngIf="alerta?.id_contrato">

--- a/client/src/app/busca/busca-fornecedor/busca-fornecedor.component.html
+++ b/client/src/app/busca/busca-fornecedor/busca-fornecedor.component.html
@@ -90,7 +90,7 @@
                   <br>
                   <small>
                     <ngb-highlight
-                      [result]="fornecedor?.nr_documento | formatCpfCnpj"
+                      [result]="fornecedor?.nr_documento | formatCpfCnpj:fornecedor?.tp_pessoa"
                       [term]="listaService.termoBusca">
                     </ngb-highlight>
                   </small>

--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -38,7 +38,7 @@
               {{ contrato?.contratoFornecedor?.nm_pessoa ? contrato?.contratoFornecedor?.nm_pessoa : 'Pessoa física (nome não divulgado)' }}
             </a>
             <br>
-            ({{ contrato?.nr_documento_contratado | formatCpfCnpj }})
+            ({{ contrato?.nr_documento_contratado | formatCpfCnpj:contrato?.contratoFornecedor?.tp_pessoa }})
           </div>
         </div>
       </div>

--- a/client/src/app/fornecedores/info-fornecedor/info-fornecedor.component.html
+++ b/client/src/app/fornecedores/info-fornecedor/info-fornecedor.component.html
@@ -1,7 +1,7 @@
 <div class="view-container" *ngIf="fornecedor">
   <app-barra-titulo [titulo]="
       fornecedor?.nm_pessoa ? fornecedor?.nm_pessoa : 'Pessoa física (nome não divulgado)'
-    " [subtitulo]="fornecedor.nr_documento | formatCpfCnpj" [exibirVoltar]="true">
+    " [subtitulo]="fornecedor.nr_documento | formatCpfCnpj:fornecedor?.tp_pessoa" [exibirVoltar]="true">
   </app-barra-titulo>
 
   <div class="container">

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-itens/licitacoes-detalhar-itens.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-itens/licitacoes-detalhar-itens.component.html
@@ -201,7 +201,7 @@
                                 </a>
                                 <br>
                                 <small>
-                                    <ngb-highlight [result]="item.nr_documento_contratado | formatCpfCnpj"></ngb-highlight>
+                                  <ngb-highlight [result]="item.nr_documento_contratado | formatCpfCnpj:item?.tp_fornecedor "></ngb-highlight>
                                 </small>
                             </div>
                             <div

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
@@ -149,7 +149,7 @@
               <br>
               <small>
                 <ngb-highlight
-                  [result]="contrato.nr_documento_contratado | formatCpfCnpj"
+                  [result]="contrato.nr_documento_contratado | formatCpfCnpj:contrato.tp_fornecedor"
                   [term]="listaService.termoBusca">
                 </ngb-highlight>
               </small>

--- a/client/src/app/shared/pipes/format-cpf-cnpj.pipe.ts
+++ b/client/src/app/shared/pipes/format-cpf-cnpj.pipe.ts
@@ -8,11 +8,14 @@ export class FormatCpfCnpjPipe implements PipeTransform {
   transform(value: any, ...args: any[]): any {
     if (!value) { return value; }
     const cnpjCpf = value.replace(/\D/g, '');
+    const tipoPessoa = args[0];
 
     if (cnpjCpf.length === 11) {
       return cnpjCpf.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/g, '\$1.\$2.\$3-\$4');
     } else if (cnpjCpf.length === 14) {
       return cnpjCpf.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/g, '\$1.\$2.\$3/\$4-\$5');
+    } else if (cnpjCpf.length === 6 && tipoPessoa === 'F') {
+      return cnpjCpf.replace(/(\d{3})(\d{3})/g, '***.\$1.\$2-**');
     }
 
     return cnpjCpf;

--- a/server/routes/api/contratos.js
+++ b/server/routes/api/contratos.js
@@ -153,6 +153,14 @@ router.get("/search", (req, res) => {
               fornecedor \
               WHERE \
               fornecedor.nr_documento = p_search.nr_documento_contratado
+            ),
+            (\
+              SELECT \
+              tp_pessoa as tp_fornecedor \
+              FROM \
+              fornecedor \
+              WHERE \
+              fornecedor.nr_documento = p_search.nr_documento_contratado
             ) \
         FROM \
             ( \

--- a/server/routes/api/fornecedores.js
+++ b/server/routes/api/fornecedores.js
@@ -28,6 +28,7 @@ router.get("/search", (req, res) => {
   let query = `SELECT \
                 nr_documento, \
                 nm_pessoa, \
+                tp_pessoa,
                 total_de_contratos, \
                 data_primeiro_contrato
               FROM \


### PR DESCRIPTION
## Mudanças

A exibição dos CPFs de fornecedores nos dados do Governo Federal, que não possuem todos os dígitos, devem ser:
***.123.456-**

Deve-se passar o tipo de pessoa (F, J ou O) para o pipe formatCpfCnpj.