### PR TITLE
Sempre exibe o fim da vigência na tela de fornecedor

### DIFF
--- a/client/src/app/fornecedores/info-fornecedor/info-fornecedor.component.ts
+++ b/client/src/app/fornecedores/info-fornecedor/info-fornecedor.component.ts
@@ -57,7 +57,6 @@ export class InfoFornecedorComponent implements OnInit {
       .pipe(map(contratos => {
         // itens ordenados pela data do inicio da vigencia
         contratos.sort((c1, c2) => new Date(c1.dt_inicio_vigencia).getTime() - new Date(c2.dt_inicio_vigencia).getTime());
-        // this.showFimVigencia = (contratos.length > 0 && contratos[0].sigla_estado !== 'BR');
         this.isLoading = false;
         return contratos;
       }));

--- a/client/src/app/fornecedores/info-fornecedor/info-fornecedor.component.ts
+++ b/client/src/app/fornecedores/info-fornecedor/info-fornecedor.component.ts
@@ -22,7 +22,7 @@ export class InfoFornecedorComponent implements OnInit {
   @ViewChildren(OrdenavelDirective) cabecalhos: QueryList<OrdenavelDirective>;
 
   public fornecedor: Fornecedor;
-  public showFimVigencia = false;
+  public showFimVigencia = true;
   public isLoading = true;
   public showSocios = 5;
   public showAtividades = 5;
@@ -57,7 +57,7 @@ export class InfoFornecedorComponent implements OnInit {
       .pipe(map(contratos => {
         // itens ordenados pela data do inicio da vigencia
         contratos.sort((c1, c2) => new Date(c1.dt_inicio_vigencia).getTime() - new Date(c2.dt_inicio_vigencia).getTime());
-        this.showFimVigencia = (contratos.length > 0 && contratos[0].sigla_estado !== 'BR');
+        // this.showFimVigencia = (contratos.length > 0 && contratos[0].sigla_estado !== 'BR');
         this.isLoading = false;
         return contratos;
       }));


### PR DESCRIPTION
Fornecedores podem ter contratos de diferentes estados, por isso a coluna deve sempre ser exibida, avisando quando a despesa é do "BR"